### PR TITLE
Declare cookies variable

### DIFF
--- a/extension/src/bg/background.js
+++ b/extension/src/bg/background.js
@@ -443,7 +443,7 @@ chrome.webRequest.onHeadersReceived.addListener(function(details) {
     }
 
     // Rewrite Set-Cookie to expose it in fetch()
-    cookies = []
+    var cookies = []
     details.responseHeaders.map(responseHeader => {
         if(responseHeader.name.toLowerCase() === 'set-cookie') {
             cookies.push(responseHeader.value);


### PR DESCRIPTION
This actually declares the cookies array in the `onHeadersReceived` listener.

Fixes #26.