### PR TITLE
Added Slack webhook support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
       # Number of bcrypt rounds for
       # storing admin panel passwords.
       BCRYPT_ROUNDS: 10
+      # set this var to enable Slack notifications for agent connect/disconnect
+      # SLACK_WEBHOOK_URL: https://hooks.slack.com/services/XXXXXX
     ports:
       - "127.0.0.1:8080:8080" # Proxy server
       - "127.0.0.1:4343:4343" # WebSocket server (talks with implants)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2199,6 +2199,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "@slack/webhook": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-6.1.0.tgz",
+      "integrity": "sha512-7AYNISyAjn/lA/VDwZ307K5ft5DojXgBd3DRrGoFN8XxIwIyRALdFhxBiMgAqeJH8eWoktvNwLK24R9hREEqpA==",
+      "requires": {
+        "@slack/types": "^1.2.1",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.4"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "whatwg-fetch": "^1.0.0",
     "ws": "^5.1.0",
     "node-forge": "^0.6.42",
-    "node-powershell": "^3.3.1"
+    "node-powershell": "^3.3.1",
+    "@slack/webhook": "^6.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -535,7 +535,7 @@ async function initialize() {
                 browserproxy_record.is_online = false;
                 await browserproxy_record.save();
 
-                slack_notify(`Browser ID \`${browserproxy_record.id}\` (${browserproxy_record.name}) disconnected`)
+                slack_notify(`Browser ID \`${browserproxy_record.browser_id}\` (${browserproxy_record.name}) disconnected`)
             } else {
                 logit(`Unauthenticated WebSocket has disconnected from us.`);
             }

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,15 @@ const crypto = require('crypto');
 const bcrypt = require('bcrypt');
 const moment = require('moment');
 
+// read webhook url from env var and init
+if(url = process.env.SLACK_WEBHOOK_URL) { 
+    const { IncomingWebhook } = require('@slack/webhook');
+    var webhook = new IncomingWebhook(url);
+}
+else {
+    console.info('No webhook defined in SLACK_WEBHOOK_URL, Slack notifications will not work');
+}
+
 function copy(input_data) {
     return JSON.parse(JSON.stringify(input_data));
 }
@@ -32,9 +41,21 @@ function logit(input_string) {
     console.log(`[${datetime}]${spacer}${input_string.trim()}`);
 }
 
+function slack_notify(input_string) {
+    // only attempt to send the message if webhook has been initialised
+    if (typeof webhook !== 'undefined') {
+        (async () => {
+            await webhook.send({
+                text: input_string,
+            });
+          })();
+    }
+}
+
 module.exports = {
     copy: copy,
     get_secure_random_string: get_secure_random_string,
     get_hashed_password: get_hashed_password,
-    logit: logit
+    logit: logit,
+    slack_notify: slack_notify
 };


### PR DESCRIPTION
Added support for Slack notifications via webhooks using [@slack/webhook](https://www.npmjs.com/package/@slack/webhook).

This expects a valid Slack webhook URL be defined in `docker-compose.yml` via the `SLACK_WEBHOOK_URL` environment variable.  If this variable is not set then a message is printed to the logs advising that Slack notifications will not be sent.